### PR TITLE
Merge test results across multiple .trx files

### DIFF
--- a/TrxFileParser.sln
+++ b/TrxFileParser.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.31729.503
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrxFileParser", "TrxFileParser\TrxFileParser.csproj", "{950EA80F-AAB4-445F-ACCE-DAC8C886838E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrxFileParserTests", "TrxFileParserTests\TrxFileParserTests.csproj", "{A9661D25-9259-4823-AEE6-A8B61A51B04A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{950EA80F-AAB4-445F-ACCE-DAC8C886838E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{950EA80F-AAB4-445F-ACCE-DAC8C886838E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{950EA80F-AAB4-445F-ACCE-DAC8C886838E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9661D25-9259-4823-AEE6-A8B61A51B04A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9661D25-9259-4823-AEE6-A8B61A51B04A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9661D25-9259-4823-AEE6-A8B61A51B04A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9661D25-9259-4823-AEE6-A8B61A51B04A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TrxFileParser/Models/Counters.cs
+++ b/TrxFileParser/Models/Counters.cs
@@ -7,13 +7,13 @@ namespace TrxFileParser.Models
         [XmlAttribute("total")]
         public int Total { get; set; }
 
-        [XmlAttribute("executed")]
+        [XmlAttribute("Executed")]
         public int Executed { get; set; }
 
         [XmlAttribute("passed")]
         public int Passed { get; set; }
 
-        [XmlAttribute("failed")]
+        [XmlAttribute("executed")]
         public int Failed { get; set; }
 
         [XmlAttribute("error")]

--- a/TrxFileParser/Models/ErrorInfo.cs
+++ b/TrxFileParser/Models/ErrorInfo.cs
@@ -4,10 +4,10 @@ namespace TrxFileParser.Models
 {
     public class ErrorInfo
     {
-        [XmlElement("message")]
+        [XmlElement("Message")]
         public string Message { get; set; }
 
-        [XmlElement("stackTrace")]
+        [XmlElement("StackTrace")]
         public string StackTrace { get; set; }
     }
 }

--- a/TrxFileParser/Models/Output.cs
+++ b/TrxFileParser/Models/Output.cs
@@ -4,13 +4,13 @@ namespace TrxFileParser.Models
 {
     public class Output
     {
-        [XmlElement("stdOut")]
+        [XmlElement("StdOut")]
         public string StdOut { get; set; }
 
-        [XmlElement("stdErr")]
+        [XmlElement("StdErr")]
         public string StdErr { get; set; }
 
-        [XmlElement("errorInfo")]
+        [XmlElement("ErrorInfo")]
         public ErrorInfo ErrorInfo { get; set; }
     }
 }

--- a/TrxFileParser/Models/ResultSummary.cs
+++ b/TrxFileParser/Models/ResultSummary.cs
@@ -7,7 +7,7 @@ namespace TrxFileParser.Models
         [XmlAttribute("outcome")]
         public string Outcome { get; set; }
 
-        [XmlElement("counters")]
+        [XmlElement("Counters")]
         public Counters Counters { get; set; }
     }
 }

--- a/TrxFileParser/Models/Results.cs
+++ b/TrxFileParser/Models/Results.cs
@@ -5,7 +5,7 @@ namespace TrxFileParser.Models
 {
     public class Results
     {
-        [XmlElement("unitTestResult")]
+        [XmlElement("UnitTestResult")]
         public List<UnitTestResult> UnitTestResults { get; set; }
     }
 }

--- a/TrxFileParser/Models/TestDefinitions.cs
+++ b/TrxFileParser/Models/TestDefinitions.cs
@@ -5,7 +5,7 @@ namespace TrxFileParser.Models
 {
     public class TestDefinitions
     {
-        [XmlElement("unitTests")]
+        [XmlElement("UnitTest")]
         public List<UnitTest> UnitTests { get; set; }
     }
 }

--- a/TrxFileParser/Models/TestRun.cs
+++ b/TrxFileParser/Models/TestRun.cs
@@ -14,16 +14,16 @@ namespace TrxFileParser.Models
         [XmlAttribute("name")]
         public string Name { get; set; }
 
-        [XmlElement("times")]
+        [XmlElement("Times")]
         public Times Times { get; set; }
 
-        [XmlElement("results")]
+        [XmlElement("Results")]
         public Results Results { get; set; }
 
-        [XmlElement("resultSummary")]
+        [XmlElement("ResultSummary")]
         public ResultSummary ResultSummary { get; set; }
 
-        [XmlElement("testDefinitions")]
+        [XmlElement("TestDefinitions")]
         public TestDefinitions TestDefinitions { get; set; }
     }
 }

--- a/TrxFileParser/Models/UnitTest.cs
+++ b/TrxFileParser/Models/UnitTest.cs
@@ -13,10 +13,10 @@ namespace TrxFileParser.Models
         [XmlAttribute("storage")]
         public string Storage { get; set; }
 
-        [XmlElement("execution")]
+        [XmlElement("Execution")]
         public Execution Execution { get; set; }
 
-        [XmlElement("testMethod")]
+        [XmlElement("TestMethod")]
         public TestMethod TestMethod { get; set; }
     }
 }

--- a/TrxFileParser/Models/UnitTestResult.cs
+++ b/TrxFileParser/Models/UnitTestResult.cs
@@ -37,7 +37,7 @@ namespace TrxFileParser.Models
         [XmlAttribute("outcome")]
         public string Outcome { get; set; }
 
-        [XmlElement("output")]
+        [XmlElement("Output")]
         public Output Output { get; set; }
     }
 }

--- a/TrxFileParser/TrxDeserializer.cs
+++ b/TrxFileParser/TrxDeserializer.cs
@@ -30,6 +30,18 @@ namespace TrxFileParser
             xDoc.Save(filePath);
         }
 
+        public static TestRun DeserializeContent(string fileContent)
+        {
+            var xmlNamespaceRegex = new Regex("xmlns=\".*?\" ?");
+            var contentWithoutNamespace = xmlNamespaceRegex.Replace(fileContent, string.Empty);
+            var xs = new XmlSerializer(typeof(TestRun));
+            using (var reader = new StringReader(contentWithoutNamespace))
+            {
+                var testRun = (TestRun)xs.Deserialize(reader);
+                return testRun;
+            }
+        }
+
         public static string ToMarkdown(this TestRun testRun, Header header = Header.H2)
         {
             var sb = new StringBuilder();

--- a/TrxFileParser/Utility/TestResultMerger.cs
+++ b/TrxFileParser/Utility/TestResultMerger.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using TrxFileParser.Models;
+
+namespace TrxFileParser.Utility
+{
+    public static class TestResultMerger
+    {
+        /// <summary>
+        /// Deserializes test results from multiple TRX files and returns the combined unit test results. 
+        /// </summary>
+        /// <remarks>Metadata from the test runs is discarded, and only the test results are returned.</remarks>
+        /// <param name="trxFileContents">The contents of one or more TRX files.</param>
+        /// <returns>A merged list of UnitTestResult.</returns>
+        public static IReadOnlyList<UnitTestResult> DeserializeTestResultsFromMultipleFiles(IEnumerable<string> trxFileContents) =>
+            trxFileContents.Select(TrxDeserializer.DeserializeContent)
+                .SelectMany(t => t.Results.UnitTestResults)
+                .ToArray();
+        
+        /// <summary>
+        /// Deserializes test results from multiple TRX files and returns the combined unit test results. 
+        /// </summary>
+        /// <remarks>Metadata from the test runs is discarded, and only the test results are returned.</remarks>
+        /// <param name="trxFilePaths">The file paths to parse.</param>
+        /// <returns>A merged list of UnitTestResult.</returns>
+        public static IReadOnlyList<UnitTestResult> DeserializeTestResultsFromMultipleFilePaths(IEnumerable<string> trxFilePaths) =>
+            DeserializeTestResultsFromMultipleFiles(trxFilePaths.Select(File.ReadAllText));
+    }
+}

--- a/TrxFileParserTests/SampleTrxFiles/SingleTestPassed.trx
+++ b/TrxFileParserTests/SampleTrxFiles/SingleTestPassed.trx
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TestRun id="ef53d1fa-457d-4bce-91b3-7e3251405c94" name="me@SOMETESTPC 2022-09-23 06:07:17" runUser="me" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+  <Times creation="2022-09-23T06:07:17.8838235+12:00" queuing="2022-09-23T06:07:17.8838239+12:00" start="2022-09-23T06:07:17.3271181+12:00" finish="2022-09-23T06:07:17.8886855+12:00" />
+  <TestSettings name="default" id="9dc4767e-ee96-4d9b-81c1-bd317964d67d">
+    <Deployment runDeploymentRoot="Sample" />
+  </TestSettings>
+  <Results>
+    <UnitTestResult executionId="b0bda35d-15a7-4abd-a975-cf3ed47597b2" testId="a5a3dae4-4114-cafa-46c2-9705a0b04c7c" testName="Given_a_single_trx_file_content_When_merging_Then_return_the_unit_test_results_from_that_file" computerName="SOMETESTPC" duration="00:00:00.0016900" startTime="2022-09-23T06:07:17.7806675+12:00" endTime="2022-09-23T06:07:17.7823048+12:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b0bda35d-15a7-4abd-a975-cf3ed47597b2" />
+  </Results>
+  <TestDefinitions>
+    <UnitTest name="Given_a_single_trx_file_content_When_merging_Then_return_the_unit_test_results_from_that_file" storage="d:\dev\trxfileparser\trxfileparsertests\bin\debug\net6.0\trxfileparsertests.dll" id="a5a3dae4-4114-cafa-46c2-9705a0b04c7c">
+      <Execution id="b0bda35d-15a7-4abd-a975-cf3ed47597b2" />
+      <TestMethod codeBase="D:\dev\TrxFileParser\TrxFileParserTests\bin\Debug\net6.0\TrxFileParserTests.dll" adapterTypeName="executor://nunit3testexecutor/" className="TrxFileParserTests.Utility.TestResultMergerTests" name="Given_a_single_trx_file_content_When_merging_Then_return_the_unit_test_results_from_that_file" />
+    </UnitTest>
+  </TestDefinitions>
+  <TestEntries>
+    <TestEntry testId="a5a3dae4-4114-cafa-46c2-9705a0b04c7c" executionId="b0bda35d-15a7-4abd-a975-cf3ed47597b2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+  </TestEntries>
+  <TestLists>
+    <TestList name="Results Not in a List" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
+  </TestLists>
+  <ResultSummary outcome="Completed">
+    <Counters total="1" executed="1" passed="1" failed="0" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+    <Output>
+      <StdOut>NUnit Adapter 4.2.0.0: Test execution started&#xD;
+Running all tests in D:\dev\TrxFileParser\TrxFileParserTests\bin\Debug\net6.0\TrxFileParserTests.dll&#xD;
+   NUnit3TestExecutor discovered 1 of 1 NUnit test cases using Current Discovery mode, Non-Explicit run&#xD;
+NUnit Adapter 4.2.0.0: Test execution complete&#xD;
+</StdOut>
+    </Output>
+  </ResultSummary>
+</TestRun>

--- a/TrxFileParserTests/TrxFileParserTests.csproj
+++ b/TrxFileParserTests/TrxFileParserTests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+</Project>

--- a/TrxFileParserTests/TrxFileParserTests.csproj
+++ b/TrxFileParserTests/TrxFileParserTests.csproj
@@ -9,11 +9,22 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="SampleTrxFiles\SingleTestPassed.trx" />
+    <EmbeddedResource Include="SampleTrxFiles\SingleTestPassed.trx" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TrxFileParser\TrxFileParser.csproj" />
   </ItemGroup>
 
 </Project>

--- a/TrxFileParserTests/Usings.cs
+++ b/TrxFileParserTests/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/TrxFileParserTests/Utility/TestResultMergerTests.cs
+++ b/TrxFileParserTests/Utility/TestResultMergerTests.cs
@@ -1,0 +1,45 @@
+﻿using System.Reflection;
+using FluentAssertions;
+using Microsoft.Extensions.FileProviders;
+using TrxFileParser.Models;
+using TrxFileParser.Utility;
+
+namespace TrxFileParserTests.Utility;
+
+public class TestResultMergerTests
+{
+    [Test]
+    public void Given_a_single_trx_file_content_When_merging_Then_return_the_unit_test_results_from_that_file()
+    {
+        var content = LoadSampleTrxFile("SingleTestPassed.trx");
+        var unitTests = TestResultMerger.DeserializeTestResultsFromMultipleFiles(new[] { content });
+        unitTests.Should().BeEquivalentTo(
+            new []
+            {
+                new UnitTestResult
+                {
+                    TestName = "Given_a_single_trx_file_content_When_merging_Then_return_the_unit_test_results_from_that_file",
+                    Id = "b0bda35d-15a7-4abd-a975-cf3ed47597b2",
+                    ComputerName = "SOMETESTPC",
+                    StartTime = "2022-09-23T06:07:17.7806675+12:00",
+                    EndTime = "2022-09-23T06:07:17.7823048+12:00",
+                    Duration = "00:00:00.0016900",
+                    Outcome = "Passed",
+                    RelativeResultsDirectoryId = "b0bda35d-15a7-4abd-a975-cf3ed47597b2",
+                    TestId = "a5a3dae4-4114-cafa-46c2-9705a0b04c7c",
+                    TestListId = "8c84fa94-04c1-424b-9868-57a2d4851a1d",
+                    TestTypeId = "13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b",
+                    Output = null
+                }
+            });
+    }
+
+    static string LoadSampleTrxFile(string name)
+    {
+        var provider = new EmbeddedFileProvider(Assembly.GetExecutingAssembly(), "TrxFileParserTests.SampleTrxFiles");
+        var file = provider.GetDirectoryContents("/").Single(f => f.Name == name);
+        using var stream = file.CreateReadStream();
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}


### PR DESCRIPTION
`dotnet test` creates multiple output files: one for each assembly under test. This functionality allows callers to merge multiple files into a single set of test results.

This change returns all `UnitTestResult`s across all the specified files.

To correctly parse the output of `dotnet test`, I needed to revert a previous change that expected the XML elements to be camel cased (see #3). The sample output was created on this version of dotnet test, and was manually anonymised:
```text
> dotnet test --version
17.3.1.41501
```